### PR TITLE
Fix for evaluation bug (issue #1)

### DIFF
--- a/jcarafe-core/src/main/scala/org/mitre/jcarafe/crf/SeqGenScorer.scala
+++ b/jcarafe-core/src/main/scala/org/mitre/jcarafe/crf/SeqGenScorer.scala
@@ -178,6 +178,10 @@ trait SeqGenScorer[Obs] extends DecodingSeqGen[Obs] {
         }
         totalTokenEntropy += getEntropy(inst.condProbTbl)
       }
+      if(s.length>0) {
+        updateSets(systemSets,curSysType,startSysIndex,s.length-1,globalIndex)
+        updateSets(goldSets,curGoldType,startGoldIndex,s.length-1,globalIndex)
+      }
       globalIndex += s.length
       globalConfidenceCorrelation = (s.seqPosteriorProbability, (1.0 - (seqTokIncorrect.toDouble / s.length)), totalTokenEntropy, s.length, 0.0) :: globalConfidenceCorrelation
     }


### PR DESCRIPTION
When comparing results with a gold set it now adds an annotation to the respective sets for the last item in each sequence. Previously it was ignoring the last item and any associated annotation span with it.
