### PR TITLE
Added "--strip" option to remove existing 'tags' from input files, addresses #8

### DIFF
--- a/jcarafe-core/src/main/scala/org/mitre/jcarafe/crf/TextSeqGen.scala
+++ b/jcarafe-core/src/main/scala/org/mitre/jcarafe/crf/TextSeqGen.scala
@@ -346,10 +346,11 @@ trait TextSeqGen extends SeqGen[String] with FactoredSeqGen[String] with XmlConv
         case Tag(t,b) :: r => 
 	  val ltag = t.startsWith("<lex") || t.startsWith("</lex")
           //if (ltag && opts.keepToks) {specialTok = true; specialTokTag = Some(t)}
+        	  val (l,attmap) = getLabelAndAttrsFromTag(t)
 	  if (ltag) { specialTok = true; specialTokTag = Some(t)}
-          else if (printExistingTags && !ltag) os.write(t)
+          else if (printExistingTags && !ltag && (!opts.stripOriginalTags || !opts.tagset.isWithin(l,attmap))) os.write(t)
+
           if (!b) { // if it's a close tag and a boundary tag, set ignore to true
-        	  val (l,_) = getLabelAndAttrsFromTag(t)
         	  if (!ignoreFlag && opts.boundaries.labelMatch(l)) ignoreFlag = true
           }
           traverse(r) 

--- a/jcarafe-core/src/main/scala/org/mitre/jcarafe/util/Options.scala
+++ b/jcarafe-core/src/main/scala/org/mitre/jcarafe/util/Options.scala
@@ -92,6 +92,7 @@ class OptionHandler(params: Array[String], check: Boolean) extends BaseOptionHan
   "--tagset"         desc "Tagset specification file"
   "--tag"            multi "Specific simple tag/label"
   "--seed"           desc "Seed random sampling"
+  "--strip"          flag "Strip original tags if present when outputting decoded files"
   //"--recode" multi "Recode sequences"
   "--num-states"     desc "Number of states for non-factored model"
   "--seq-boundary"   multi "Sequence boundary label/tag"
@@ -201,6 +202,8 @@ class Options(val argv: Array[String], val optHandler: BaseOptionHandler, val pr
       case None => 
         new Tagset(optHandler.getAll("--tag").foldLeft(Set.empty:Set[AbstractLabel]){(ac,s) => ac + parseTagSpec(s)})}
   
+  var stripOriginalTags = optHandler.check("--strip")
+
   var boundaries : Tagset = 
     new Tagset(optHandler.getAll("--seq-boundary").foldLeft(Set.empty:Set[AbstractLabel]){(ac,s) => ac + parseTagSpec(s)})
 
@@ -315,8 +318,10 @@ class Options(val argv: Array[String], val optHandler: BaseOptionHandler, val pr
     no.sgd_=(sgd)
     no.streaming_=(streaming)
     no.tagset_=(tagset)
+    no.stripOriginalTags_=(stripOriginalTags)
     no.tokenizerPatterns_=(tokenizerPatterns)
     no.train_=(train)
+    no.seed_=(seed)
     no.unlabeledInputDir_=(unlabeledInputDir)
     no.useSpaces_=(useSpaces)
     no.weightedFeatureMap_=(weightedFeatureMap)


### PR DESCRIPTION
The "--strip" option will ignore outputting any markup in the text formatted files that matches with supplied tagset information. So you can use the same tagset as used during testing to ignore any in the input files, so you will only be left with those generated from the decoding process. This prevents getting duplicated and/or overlapping tags in the text output, which then allows for simple side-by-side comparison of the input and output to compare matching tags.

This patch does not preserve any attributes of elements not used in the tag/tagset specifications the entire element with its attributes is stripped is it matches the tagset.

Note -this uses the tag and tagset options arguments when running the process. I did not check whether this information is encoded as part of the model file which would remove the need to supply them during decoding. 
